### PR TITLE
Fixed the missing username in signup

### DIFF
--- a/scripts/components/session/SignupPage.react.jsx
+++ b/scripts/components/session/SignupPage.react.jsx
@@ -31,7 +31,7 @@ var SignupPage = React.createClass({
     if (password !== passwordConfirmation) {
       this.setState({ errors: ['Password and password confirmation should match']});
     } else {
-      SessionActionCreators.signup(email, password, passwordConfirmation);
+      SessionActionCreators.signup(email, username, password, passwordConfirmation);
     }
   },
 


### PR DESCRIPTION
The user's password was displayed in the stories list instead of the username because of the missing parameter in the singup
